### PR TITLE
Use Idiomatic Shell

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,5 +1,0 @@
-with import <nixpkgs> { };
-stdenv.mkDerivation {
-  name = "pompom";
-  buildInputs = [ pkg-config alsa-lib ];
-}

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,5 @@
+{pkgs ? import <nixpkgs> {}}:
+pkgs.mkShell {
+  name = "pompom";
+  packages = with pkgs; [ pkg-config alsa-lib ];
+}


### PR DESCRIPTION
Shell derivations should be in `shell.nix` and use `mkShell`. `with import` is probably a bad idea too (aside from being a global `with` expression), especially since we can just make the file a function. It's not unlike `using namespace std;` in C++, you just don't do it.